### PR TITLE
Lumen support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "illuminate/mail": "^5.2"
+        "illuminate/mail": "^5.2",
+        "illuminate/view": "^5.2"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "illuminate/mail": "^5.2",
-        "illuminate/view": "^5.2"
+        "illuminate/mail": "^5.1",
+        "illuminate/view": "^5.1"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "5.2.*|5.3.*"
+        "illuminate/mail": "^5.2"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",


### PR DESCRIPTION
Pulling in the entire Laravel Framework causes issues when trying to use this package in a Lumen application. These incompatibilities can be avoided by explicitly requiring only the necessary sub-packages, namely `illuminate/mail` and `illuminate/view`.

I have tested this with a fresh Lumen installation as well as an existing Lumen application.