### PR TITLE
Fix syntax error in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Route::post('register', function () {
 
     Mail::send('emails.welcome', [], function ($m) {
         $email = request('email');
-        $m->to($email),
+        $m->to($email);
         $m->subject('Welcome to my app!');
         $m->from('noreply@example.com');
         $m->bcc('notifications@example.com');


### PR DESCRIPTION
Very minor fix to the example in the readme. Copy-pasting the example no longer gives you a syntax error. I've tripped over this often enough to make this PR :bell: