### PR TITLE
Use array_shift instead of Arr::first()

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -44,7 +44,7 @@ class Message
 
     public function getBody($part = 'html')
     {
-        return Arr::get($this->view, $part, Arr::first($this->view));
+        return Arr::get($this->view, $part, array_shift($this->view));
     }
 
     public function subject($subject)


### PR DESCRIPTION
Laravel Arr::first expects the second param to be a closure as instead of returning the first item of an array, it's made to return the first item in an array which matches a condition. (Trying to get the body content fails currently).