### PR TITLE
Fix the error of missing addPart method

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -156,4 +156,9 @@ class Message
     {
         throw new Exception("Cannot get Swift message from MailThief message.");
     }
+
+    public function addPart($body, $contentType = null, $charset = null)
+    {
+
+    }
 }


### PR DESCRIPTION
This will fix issue #8 where a missing method addPart can happen with attempting to add message parts like content types.