### PR TITLE
Fix the error with Arr::First not having a callable in Laravel 5.1

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -44,7 +44,7 @@ class Message
 
     public function getBody($part = 'html')
     {
-        return Arr::get($this->view, $part, Arr::first($this->view));
+        return Arr::get($this->view, $part, Arr::first($this->view, function ($value) { return $value;}));
     }
 
     public function subject($subject)
@@ -155,5 +155,10 @@ class Message
     public function getSwiftMessage()
     {
         throw new Exception("Cannot get Swift message from MailThief message.");
+    }
+
+    public function getView($part = '')
+    {
+        return (empty($part)) ? $this->view : $this->getBody($part);
     }
 }


### PR DESCRIPTION
I am not in love with this but I don't know if there is anything else that can be done.  

Arr::First requires a callable to work in 5.1.  If not it will throw an error.  

See: 
https://github.com/illuminate/support/blob/5.1/Arr.php#L150
vs
https://github.com/illuminate/support/blob/master/Arr.php#L134