### PR TITLE
Replace usage of `Arr::first` with native `reset`

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -44,7 +44,7 @@ class Message
 
     public function getBody($part = 'html')
     {
-        return Arr::get($this->view, $part, Arr::first($this->view));
+        return Arr::get($this->view, $part, reset($this->view));
     }
 
     public function subject($subject)

--- a/tests/MailThiefTest.php
+++ b/tests/MailThiefTest.php
@@ -285,4 +285,26 @@ class MailThiefTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($mailer->lastMessage()->contains('kind', 'raw'));
     }
+
+    public function test_get_body_html()
+    {
+        $mailer = $this->getMailThief();
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->to('john@example.com');
+        });
+
+        $this->assertEquals('stubbed rendered view', $mailer->lastMessage()->getBody());
+    }
+
+    public function test_get_body_raw()
+    {
+        $mailer = $this->getMailThief();
+
+        $mailer->raw('Raw text content', function ($m) {
+            $m->to('john@example.com');
+        });
+
+        $this->assertEquals('Raw text content', $mailer->lastMessage()->getBody());
+    }
 }


### PR DESCRIPTION
Arr::first on Laravel 5.1 requires a callback, thanks to @T3chn0crat
and @amonger for bringing this up in PRs.

https://github.com/tightenco/mailthief/pull/23
https://github.com/tightenco/mailthief/pull/25

We don't want to use `array_shift` because it's destructive and using a filler callback seemed like not the best approach. Decided to copy `Arr::first`'s implementation and use `reset` instead. 