### PR TITLE
Add lastMessage() to InteractsWithMail trait

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,6 @@ If you're copying this sample test, remember to create an email view at `resourc
 Example test:
 
 ```php
-use MailThief\Facades\MailThief;
 use MailThief\Testing\InteractsWithMail;
 
 class RegistrationTest extends TestCase
@@ -65,12 +64,12 @@ class RegistrationTest extends TestCase
         // Make sure the email was sent from the correct address
         // (`from` can be a list, so we return it as a collection)
         $this->seeMessageFrom('noreply@example.com');
-        
+
         // Make sure the email contains text in the body of the message
         // Default is to search the html rendered view
-        $this->assertTrue(MailThief::lastMessage()->contains('Some text in the message'));
+        $this->assertTrue($this->lastMessage()->contains('Some text in the message'));
         // To search in the raw text
-        $this->assertTrue(MailThief::lastMessage()->contains('Some text in the message', 'raw'));
+        $this->assertTrue($this->lastMessage()->contains('Some text in the message', 'raw'));
     }
 }
 ```

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -41,7 +41,7 @@ trait InteractsWithMail
     {
         $this->seeMessage();
 
-        $lastSubject = $this->getMailer()->lastMessage()->subject;
+        $lastSubject = $this->lastMessage()->subject;
 
         $this->assertEquals(
             $subject,
@@ -60,7 +60,7 @@ trait InteractsWithMail
     {
         $this->seeMessage();
 
-        $from = $this->getMailer()->lastMessage()->from->first();
+        $from = $this->lastMessage()->from->first();
 
         $this->assertEquals(
             $email,
@@ -75,10 +75,15 @@ trait InteractsWithMail
         return $this;
     }
 
+    public function lastMessage()
+    {
+        return $this->getMailer()->lastMessage();
+    }
+
     protected function seeMessage()
     {
         $this->assertNotNull(
-            $this->getMailer()->lastMessage(),
+            $this->lastMessage(),
             'Unable to find a generated email.'
         );
 


### PR DESCRIPTION
Allows (slightly) simpler visibility to last message which is frequently
the basis of assertions related to mail.