### PR TITLE
Basic Laravel 5.3 compatibility (re-merge)

### DIFF
--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -102,7 +102,7 @@ class MailThief implements Mailer, MailQueue
 
     public function hasMessageFor($email)
     {
-        return $this->messages->contains(function ($i, Message $message) use ($email) {
+        return $this->messages->contains(function (Message $message) use ($email) {
             return $message->hasRecipient($email);
         });
     }

--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -35,8 +35,9 @@ class MailThief implements Mailer, MailQueue
         $this->messages[] = $message;
     }
 
-    public function send($view, array $data, $callback)
+    public function send($view, array $data = [], $callback = null)
     {
+        $callback = $callback ?: null;
         $message = Message::fromView($this->renderViews($view, $data), $data);
         $callback($message);
         $this->messages[] = $message;

--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -22,6 +22,11 @@ class MailThief implements Mailer, MailQueue
         $this->later = collect();
     }
 
+    public static function instance()
+    {
+        return app(MailThief::class);
+    }
+
     public function hijack()
     {
         Mail::swap($this);


### PR DESCRIPTION
Initial 5.3 compatibility (#37), full Mailable support pending #30.

(Re-merging w/o squashing so #30's base isn't messed up)