### PR TITLE
Bumps illuminate package versions to L5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "illuminate/mail": "^5.1",
-        "illuminate/view": "^5.1"
+        "illuminate/mail": "^5.3",
+        "illuminate/view": "^5.3"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",


### PR DESCRIPTION
Tests were failing on my local, and it was because the Illuminate package that were being required are outdated.