### PR TITLE
Implement custom collection class so we can standardize on `contains` implementation across Laravel versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "^5.4"
+        "laravel/framework": "^5.1",
+        "phpunit/phpunit": "^5.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -2,12 +2,13 @@
 
 namespace MailThief;
 
-use InvalidArgumentException;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Mail;
-use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\MailQueue;
+use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Mail;
+use InvalidArgumentException;
 
 class MailThief implements Mailer, MailQueue
 {
@@ -107,9 +108,15 @@ class MailThief implements Mailer, MailQueue
 
     public function hasMessageFor($email)
     {
-        return $this->messages->contains(function (Message $message) use ($email) {
-            return $message->hasRecipient($email);
-        });
+        if (str_contains(app()::VERSION, '5.3')) {
+            return $this->messages->contains(function (Message $message) use ($email) {
+                return $message->hasRecipient($email);
+            });
+        } else {
+            return $this->messages->contains(function ($i, Message $message) use ($email) {
+                return $message->hasRecipient($email);
+            });
+        }
     }
 
     public function lastMessage()

--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Mail;
 use InvalidArgumentException;
+use MailThief\Support\MailThiefCollection;
 
 class MailThief implements Mailer, MailQueue
 {
@@ -19,8 +20,8 @@ class MailThief implements Mailer, MailQueue
     public function __construct(Factory $views)
     {
         $this->views = $views;
-        $this->messages = collect();
-        $this->later = collect();
+        $this->messages = new MailThiefCollection;
+        $this->later = new MailThiefCollection;
     }
 
     public static function instance()
@@ -108,15 +109,9 @@ class MailThief implements Mailer, MailQueue
 
     public function hasMessageFor($email)
     {
-        if (str_contains(app()::VERSION, '5.3')) {
-            return $this->messages->contains(function (Message $message) use ($email) {
-                return $message->hasRecipient($email);
-            });
-        } else {
-            return $this->messages->contains(function ($i, Message $message) use ($email) {
-                return $message->hasRecipient($email);
-            });
-        }
+        return $this->messages->contains(function (Message $message) use ($email) {
+            return $message->hasRecipient($email);
+        });
     }
 
     public function lastMessage()

--- a/src/Support/MailThiefCollection.php
+++ b/src/Support/MailThiefCollection.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MailThief\Support;
+
+use Illuminate\Support\Collection;
+
+class MailThiefCollection extends Collection
+{
+    /**
+     * Identical to the 5.3 implementation of contains
+     */
+    public function contains($key, $value = null)
+    {
+        if (func_num_args() == 2) {
+            return $this->contains(function ($item) use ($key, $value) {
+                return data_get($item, $key) == $value;
+            });
+        }
+
+        if ($this->useAsCallable($key)) {
+            return ! is_null($this->first($key));
+        }
+
+        return in_array($key, $this->items);
+    }
+}

--- a/tests/InteractsWithMailTest.php
+++ b/tests/InteractsWithMailTest.php
@@ -1,20 +1,12 @@
 <?php
 
 use Illuminate\Contracts\View\Factory;
-use Illuminate\Foundation\Application;
 use MailThief\MailThief;
 use MailThief\Testing\InteractsWithMail;
 
 class InteractsWithMailTest extends PHPUnit_Framework_TestCase
 {
     use InteractsWithMail;
-
-    public function setUp()
-    {
-        parent::setUp();
-
-        $app = new Application;
-    }
 
     private function getViewFactory()
     {

--- a/tests/InteractsWithMailTest.php
+++ b/tests/InteractsWithMailTest.php
@@ -1,12 +1,20 @@
 <?php
 
-use MailThief\MailThief;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Foundation\Application;
+use MailThief\MailThief;
 use MailThief\Testing\InteractsWithMail;
 
 class InteractsWithMailTest extends PHPUnit_Framework_TestCase
 {
     use InteractsWithMail;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $app = new Application;
+    }
 
     private function getViewFactory()
     {

--- a/tests/MailThiefTest.php
+++ b/tests/MailThiefTest.php
@@ -1,19 +1,10 @@
 <?php
 
-use Illuminate\Container\Container;
 use Illuminate\Contracts\View\Factory;
-use Illuminate\Foundation\Application;
 use MailThief\MailThief;
 
 class MailThiefTest extends PHPUnit_Framework_TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $app = new Application;
-    }
-
     private function getViewFactory()
     {
         $factory = Mockery::mock(Factory::class);

--- a/tests/MailThiefTest.php
+++ b/tests/MailThiefTest.php
@@ -1,10 +1,19 @@
 <?php
 
-use MailThief\MailThief;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Foundation\Application;
+use MailThief\MailThief;
 
 class MailThiefTest extends PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        $app = new Application;
+    }
+
     private function getViewFactory()
     {
         $factory = Mockery::mock(Factory::class);


### PR DESCRIPTION
As discussed in #37, our hope is to support old Laravel versions within the same package. This PR implements this for the updated @contains method in Laravel 5.3.