### PR TITLE
Add Laravel 5.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "illuminate/mail": "^5.1",
-        "illuminate/view": "^5.1"
+        "illuminate/mail": "^5.0",
+        "illuminate/view": "^5.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",


### PR DESCRIPTION
Similar to #13, a full sample repo was created with Laravel 5.0 and MailThief tests successfully pass: https://github.com/besologic/mailthief-laravel-5.0