### PR TITLE
Add ability to get subjects and make assertions against a group of them

### DIFF
--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -164,4 +164,9 @@ class MailThief implements Mailer, MailQueue
     {
         $this->from = ['address' => $address, 'name' => $name];
     }
+
+    public function subjects()
+    {
+        return $this->messages->pluck('subject');
+    }
 }

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -93,6 +93,15 @@ trait InteractsWithMail
         return $this;
     }
 
+    protected function seeInSubjects($subjects)
+    {
+        $subjects = (array) $subjects;
+
+        foreach ($subjects as $subject) {
+            $this->assertTrue(in_array($subject, $this->mailer->subjects()->all()));
+        }
+    }
+
     protected function seeMessage()
     {
         $this->assertNotNull(

--- a/tests/InteractsWithMailTest.php
+++ b/tests/InteractsWithMailTest.php
@@ -52,6 +52,32 @@ class InteractsWithMailTest extends TestCase
         $this->seeMessageWithSubject('foo');
     }
 
+    public function test_see_in_subjects()
+    {
+        $mailer = $this->mailer = $this->getMailThief();
+
+        collect(['foo@bar.tld', 'baz@qux.tld'])->each(function ($email) use ($mailer) {
+            $mailer->send('example-view', [], function ($m) use ($email) {
+                $m->subject("Message for {$email}");
+            });
+        });
+
+        $this->seeInSubjects("Message for baz@qux.tld");
+    }
+
+    public function test_see_in_subjects_with_array()
+    {
+        $mailer = $this->mailer = $this->getMailThief();
+
+        collect(['Taylor Otwell', 'Adam Wathan'])->each(function ($name) use ($mailer) {
+            $mailer->send('example-view', [], function ($m) use ($name) {
+                $m->subject("Message for {$name}");
+            });
+        });
+
+        $this->seeInSubjects(["Message for Taylor Otwell", "Message for Adam Wathan"]);
+    }
+
     public function test_see_message_from()
     {
         $mailer = $this->mailer = $this->getMailThief();

--- a/tests/MailThiefTest.php
+++ b/tests/MailThiefTest.php
@@ -102,7 +102,7 @@ class MailThiefTest extends TestCase
     public function test_global_from_is_respected()
     {
         $mailer = $this->getMailThief();
-        
+
         $mailer->alwaysFrom('john@example.com');
 
         $mailer->send('example-view', [], function ($m) {
@@ -115,7 +115,7 @@ class MailThiefTest extends TestCase
     public function test_global_from_gets_overwritten_if_specified()
     {
         $mailer = $this->getMailThief();
-        
+
         $mailer->alwaysFrom('john@example.com');
 
         $mailer->send('example-view', [], function ($m) {
@@ -226,7 +226,7 @@ class MailThiefTest extends TestCase
     public function test_global_from_is_respected_when_email_is_queued()
     {
         $mailer = $this->getMailThief();
-        
+
         $mailer->alwaysFrom('john@example.com');
 
         $mailer->queue('example-view', [], function ($m) {
@@ -272,7 +272,7 @@ class MailThiefTest extends TestCase
     public function test_global_from_is_respected_when_email_set_to_later_with_a_delay()
     {
         $mailer = $this->getMailThief();
-        
+
         $mailer->alwaysFrom('john@example.com');
 
         $mailer->later(10, 'example-view', [], function ($m) {
@@ -402,5 +402,20 @@ class MailThiefTest extends TestCase
         });
 
         $this->assertEquals(['foo@bar.tld' => 'First Last'], $mailer->lastMessage()->from->all());
+    }
+
+    public function test_it_gets_subjects()
+    {
+        $mailer = $this->getMailThief();
+
+        collect(['foo@bar.tld', 'baz@qux.tld'])->each(function ($email) use ($mailer) {
+            $mailer->send('example-view', [], function ($m) use ($email) {
+                $m->subject("Message for {$email}");
+            });
+        });
+
+        $messages = ["Message for foo@bar.tld", "Message for baz@qux.tld"];
+
+        $this->assertEquals($messages, $mailer->subjects()->all());
     }
 }


### PR DESCRIPTION
This PR adds a `subjects` method which simply collects all of the "stolen" message subjects. It also adds a method `seeInSubjects` which gives the ability to assert that certain subjects are inside a group of messages.

```php
$this->seeInSubjects("Invoice {$invoice->reference} from {$invoice->team->name}");
```