### PR TITLE
Add Messages Accessors

### DIFF
--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -36,13 +36,9 @@ trait InteractsWithMail
     public function getMessagesFor(array $emails)
     {
         return $this->getMessages()->filter(function (Message $message) use ($emails) {
-            foreach ($emails as $email) {
-                if ($message->hasRecipient($email)) {
-                    return true;
-                }
-            }
-
-            return false;
+            return collect($emails)->contains(function ($email) use ($message) {
+                return $message->hasRecipient($email);
+            });
         });
     }
 

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -30,11 +30,13 @@ trait InteractsWithMail
     }
 
     /**
-     * @param array $emails
+     * @param array|string $emails
      * @return MailThiefCollection
      */
     public function getMessagesFor(array $emails)
     {
+        $emails = (array) $emails;
+
         return $this->getMessages()->filter(function (Message $message) use ($emails) {
             return collect($emails)->contains(function ($email) use ($message) {
                 return $message->hasRecipient($email);
@@ -48,7 +50,7 @@ trait InteractsWithMail
      */
     public function getLastMessageFor($email)
     {
-        return $this->getMessagesFor((array) $email)->last();
+        return $this->getMessagesFor($email)->last();
     }
 
     /** @before */

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -35,10 +35,10 @@ trait InteractsWithMail
      */
     public function getMessagesFor($emails)
     {
-        $emails = (array) $emails;
+        $emails = collect((array) $emails);
 
         return $this->getMessages()->filter(function (Message $message) use ($emails) {
-            return collect($emails)->contains(function ($email) use ($message) {
+            return $emails->contains(function ($email) use ($message) {
                 return $message->hasRecipient($email);
             });
         });

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -47,12 +47,12 @@ trait InteractsWithMail
     }
 
     /**
-     * @param string $email
+     * @param array|string $email
      * @return Message
      */
-    public function getLastMessageFor(string $email)
+    public function getLastMessageFor($email)
     {
-        return $this->getMessagesFor([$email])->last();
+        return $this->getMessagesFor((array) $email)->last();
     }
 
     /** @before */

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -3,6 +3,8 @@
 namespace MailThief\Testing;
 
 use MailThief\Facades\MailThief;
+use MailThief\Message;
+use MailThief\Support\MailThiefCollection;
 use Illuminate\Contracts\Mail\Mailer;
 
 trait InteractsWithMail
@@ -17,6 +19,40 @@ trait InteractsWithMail
     private function getMailer()
     {
         return $this->mailer ?: MailThief::getFacadeRoot();
+    }
+    
+    /**
+     * @return MailThiefCollection
+     */
+    private function getMessages()
+    {
+        return $this->getMailer()->messages
+    }
+
+    /**
+     * @param array $emails
+     * @return MailThiefCollection
+     */
+    private function getMessagesFor(array $emails)
+    {
+        return $this->getMessages()->filter(function (Message $message) use ($emails) {
+            foreach ($emails as $email) {
+                if ($message->hasRecipient($email)) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    /**
+     * @param string $email
+     * @return Message
+     */
+    private function getLastMessageFor(string $email)
+    {
+        return $this->getMessagesFor([$email])->last();
     }
 
     /** @before */

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -24,7 +24,7 @@ trait InteractsWithMail
     /**
      * @return MailThiefCollection
      */
-    private function getMessages()
+    public function getMessages()
     {
         return $this->getMailer()->messages
     }
@@ -33,7 +33,7 @@ trait InteractsWithMail
      * @param array $emails
      * @return MailThiefCollection
      */
-    private function getMessagesFor(array $emails)
+    public function getMessagesFor(array $emails)
     {
         return $this->getMessages()->filter(function (Message $message) use ($emails) {
             foreach ($emails as $email) {
@@ -50,7 +50,7 @@ trait InteractsWithMail
      * @param string $email
      * @return Message
      */
-    private function getLastMessageFor(string $email)
+    public function getLastMessageFor(string $email)
     {
         return $this->getMessagesFor([$email])->last();
     }

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -33,7 +33,7 @@ trait InteractsWithMail
      * @param array|string $emails
      * @return MailThiefCollection
      */
-    public function getMessagesFor(array $emails)
+    public function getMessagesFor($emails)
     {
         $emails = (array) $emails;
 

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -20,13 +20,13 @@ trait InteractsWithMail
     {
         return $this->mailer ?: MailThief::getFacadeRoot();
     }
-    
+
     /**
      * @return MailThiefCollection
      */
     public function getMessages()
     {
-        return $this->getMailer()->messages
+        return $this->getMailer()->messages;
     }
 
     /**

--- a/tests/InteractsWithMailTest.php
+++ b/tests/InteractsWithMailTest.php
@@ -20,6 +20,66 @@ class InteractsWithMailTest extends TestCase
         return;
     }
 
+    public function test_get_messages()
+    {
+        $mailer = $this->mailer = $this->getMailThief();
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->to('john@example.com');
+        });
+
+        $message = $this->getMessages()->first();
+
+        static::assertEquals(['john@example.com'], $message->to->toArray());
+    }
+
+    public function test_get_messages_for()
+    {
+        $mailer = $this->mailer = $this->getMailThief();
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->to('john@example.com');
+        });
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->to(['john@example.com', 'jay@example.com']);
+        });
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->to('jay@example.com');
+        });
+
+        $messages = $this->getMessagesFor(['john@example.com']);
+
+        static::assertEquals(2, $messages->count());
+
+        foreach ($messages as $message) {
+            static::assertTrue($message->to->contains('john@example.com'));
+        }
+    }
+
+    public function test_get_last_message_for()
+    {
+        $mailer = $this->mailer = $this->getMailThief();
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->to('john@example.com');
+        });
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->to(['john@example.com', 'jay@example.com']);
+        });
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->to('jay@example.com');
+        });
+
+        $message = $this->getLastMessageFor(['john@example.com']);
+
+        static::assertTrue($message->to->contains('john@example.com'));
+        static::assertTrue($message->to->contains('jay@example.com'));
+    }
+
     public function test_hijack_mail()
     {
         $mailer = $this->mailer = $this->getMockMailThief();


### PR DESCRIPTION
I find myself in situations where other messages may have been sent after the one that I'm interested in making an assertion about. I can continue to have these locally, but they should be of more general use to others.

In particular, this should help with #53. The assertion methods may easily be rewritten to take advantage of these methods to become more general in which email gets matched.
