### PR TITLE
Update `contains` signature to match Laravel Support 5.4

### DIFF
--- a/src/Support/MailThiefCollection.php
+++ b/src/Support/MailThiefCollection.php
@@ -9,7 +9,7 @@ class MailThiefCollection extends Collection
     /**
      * Identical to the 5.3 implementation of contains
      */
-    public function contains($key, $value = null)
+    public function contains($key, $operator = null, $value = null)
     {
         if (func_num_args() == 2) {
             return $this->contains(function ($item) use ($key, $value) {


### PR DESCRIPTION
With the release of Laravel 5.4 I got:

```
1) InteractsWithMailTest::test_get_messages
Declaration of MailThief\Support\MailThiefCollection::contains($key, $value = NULL) should be compatible with Illuminate\Support\Collection::contains($key, $operator = NULL, $value = NULL)

/home/thibaud/Code/mailthief/src/Support/MailThiefCollection.php:7
/home/thibaud/Code/mailthief/src/MailThief.php:25
/home/thibaud/Code/mailthief/tests/TestCase.php:52
/home/thibaud/Code/mailthief/tests/InteractsWithMailTest.php:25

ERRORS!
```

I just update the signature without changing the implementation because I think the only usage of `contains` in the source code is with only a closure or a value (one argument). 