### PR TITLE
link to Laravel documentation instead of source

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,6 @@ class RegistrationTest extends TestCase
 
 MailThief supports just about everything you can do with the regular Laravel `Mailer` and `Message` classes. More detailed documentation is coming soon, but in the mean time, explore the [MailThief](https://github.com/tightenco/mailthief/blob/master/src/MailThief.php) and [Message](https://github.com/tightenco/mailthief/blob/master/src/Message.php) classes to get an idea of what's available.
 
-If you’re using the new Mailables syntax in Laravel 5.3, you can use the [native mail assertions](https://github.com/laravel/framework/commit/5deab59e89b85e09b2bd1642e4efe55e933805ca). But if you’re using the classic mail syntax in any version of Laravel, MailThief is still your best option.
+If you’re using the new Mailables syntax in Laravel 5.3, you can use the [native mail assertions](https://laravel.com/docs/master/mocking#mail-fake). But if you’re using the classic mail syntax in any version of Laravel, MailThief is still your best option.
 
 


### PR DESCRIPTION
Now that Laravel 5.3 is no longer new it's easier to direct the reader to the released HTML documentation.