### PR TITLE
[Laravel 5.4] Remove obsolete `renderViews` method

### DIFF
--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -60,20 +60,9 @@ class MailThief implements Mailer, MailQueue
     public function send($view, array $data = [], $callback = null)
     {
         $callback = $callback ?: null;
-        $message = Message::fromView($this->renderViews($view, $data), $data);
+        $message = Message::fromView($this->parseView($view), $data);
         $this->prepareMessage($message, $callback);
         $this->messages[] = $message;
-    }
-
-    private function renderViews($view, $data)
-    {
-        return collect($this->parseView($view))->map(function ($template, $part) use ($data) {
-            if ($part == 'raw') {
-                return $template;
-            }
-
-            return $this->views->make($template, $data)->render();
-        })->all();
     }
 
     protected function parseView($view)


### PR DESCRIPTION
To be honest, I didn't invest an awful lot of time into this. So please check before merging!

I'm using Laravel 5.4 & unfortunately MailThief didn't work for me.
In my particular case an exception `InvalidArgumentException("View [$name] not found.");` was thrown in `vendor/laravel/framework/src/Illuminate/View/FileViewFinder.php:138` because it basically tried to find a `$name` with the complete contents of a html mail.

After a little bit of debugging, it looked to me like `renderViews` tries to render something that is already rendered when the method gets called.

Testing with MailThief now works for me.