### PR TITLE
Issue #65: Fixing issue where HTML View throw an error.

### DIFF
--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -67,14 +67,14 @@ class MailThief implements Mailer, MailQueue
 
     private function renderViews($view, $data)
     {
-        return collect($this->parseView($view))->map(function ($view, $part) use ($data) {
+        return collect($this->parseView($view))->map(function ($template, $part) use ($data) {
             if ($part == 'raw') {
-                return $view;
+                return $template;
             }
 
-            return $view instanceof HtmlString
-                            ? $view->toHtml()
-                            : $this->views->make($view, $data)->render();
+            return $template instanceof HtmlString
+                            ? $template->toHtml()
+                            : $this->views->make($template, $data)->render();
         })->all();
     }
 

--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -67,12 +67,14 @@ class MailThief implements Mailer, MailQueue
 
     private function renderViews($view, $data)
     {
-        return collect($this->parseView($view))->map(function ($template, $part) use ($data) {
+        return collect($this->parseView($view))->map(function ($view, $part) use ($data) {
             if ($part == 'raw') {
-                return $template;
+                return $view;
             }
 
-            return $this->views->make($template, $data)->render();
+            return $view instanceof HtmlString
+                            ? $view->toHtml()
+                            : $this->views->make($view, $data)->render();
         })->all();
     }
 

--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use InvalidArgumentException;
 use MailThief\Support\MailThiefCollection;


### PR DESCRIPTION
Closes #65

---

When attempting to catch the `reset password` email using Laravel 5.4, I get the following error.

```
Caused by
InvalidArgumentException: View [<html email>] not found. in /Users/username/app/vendor/laravel/framework/src/Illuminate/View/FileViewFinder.php:137
Stack trace:
#0 /Users/username/app/vendor/laravel/framework/src/Illuminate/View/FileViewFinder.php(79): Illuminate\View\FileViewFinder->findInPaths('<!DOCTYPE html ...', Array)
#1 /Users/username/app/vendor/laravel/framework/src/Illuminate/View/Factory.php(128): Illuminate\View\FileViewFinder->find('<!DOCTYPE html ...')
#2 /Users/username/app/vendor/tightenco/mailthief/src/MailThief.php(75): Illuminate\View\Factory->make('<!DOCTYPE html ...', Array)
#3 [internal function]: MailThief\MailThief->MailThief\{closure}(Object(Illuminate\Support\HtmlString), 'html')
```

I believe it's because the view is coming back as an instance of `Illuminate\Support\HtmlString` but the `renderViews` method is attempting to locate the view file [here](https://github.com/tightenco/mailthief/blob/master/src/MailThief.php#L75).

I believe the fix here is to make MailThief's `renderViews` method fall more in line with the `renderView` method in `Illuminate/Mail/Mailer`. ([Link](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Mail/Mailer.php#L297))

