### PR TITLE
Call mailer getter in seeInSubjects

### DIFF
--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -132,7 +132,7 @@ trait InteractsWithMail
         $subjects = (array) $subjects;
 
         foreach ($subjects as $subject) {
-            $this->assertTrue(in_array($subject, $this->mailer->subjects()->all()));
+            $this->assertTrue(in_array($subject, $this->getMailer()->subjects()->all()));
         }
     }
 


### PR DESCRIPTION
`$this->mailer->subjects()` raises Fatal Error when the mailer wasn't set explicitly.

Also, for consistency with the rest of the methods.