### PR TITLE
Fix: trait method seeMessageFrom should work when from set with name

### DIFF
--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -94,7 +94,9 @@ trait InteractsWithMail
     {
         $this->seeMessage();
 
-        $from = $this->lastMessage()->from->first();
+        $from = $this->lastMessage()->from->map(function ($value, $key) {
+            return is_numeric($key) ? $value : $key;
+        })->first();
 
         $this->assertEquals(
             $email,

--- a/tests/InteractsWithMailTest.php
+++ b/tests/InteractsWithMailTest.php
@@ -148,6 +148,13 @@ class InteractsWithMailTest extends TestCase
         });
 
         $this->seeMessageFrom('me@example.com');
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->from('me2@example.com', 'Name');
+            $m->to('john@example.com');
+        });
+
+        $this->seeMessageFrom('me2@example.com');
     }
 
     public function test_see_headers_for()


### PR DESCRIPTION
Trait fix. method seeMessageFrom is incorrect in case when we set the sender name