### PR TITLE
Support for overwriting the recipient

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -76,8 +76,12 @@ class Message
         return $this;
     }
 
-    public function to($address, $name = null)
+    public function to($address, $name = null, $override = false)
     {
+        if ($override) {
+            $this->to = collect();
+        }
+        
         if (! is_array($address)) {
             $address = $name ? [$address => $name] : [$address];
         }

--- a/tests/MailThiefTest.php
+++ b/tests/MailThiefTest.php
@@ -16,6 +16,17 @@ class MailThiefTest extends TestCase
 
         $this->assertTrue($mailer->hasMessageFor('john@example.com'));
     }
+    
+    public function test_overwrite_recipient()
+    {
+        $mailer = $this->getMailThief();
+
+        $mailer->send('example-view', [], function ($m) {
+            $m->to('john@example.com')->to('jane@example.com', null, true);
+        });
+
+        $this->assertTrue($mailer->hasMessageFor('jane@example.com'));
+    }
 
     public function test_send_to_multiple_recipients()
     {


### PR DESCRIPTION
The Laravel `message` class supports overwriting the recipient. This pull request brings support for that to MailThief.

https://laravel.com/api/5.4/Illuminate/Mail/Message.html#method_to