### PR TITLE
Update MailThief to support breaking changes in laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         }
     ],
     "require": {
-        "illuminate/mail": ">=5.0 <5.5",
-        "illuminate/view": ">=5.0 <5.5"
+        "illuminate/mail": "^5.5",
+        "illuminate/view": "^5.5"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "laravel/framework": ">=5.0 <5.5",
+        "laravel/framework": "^5.5",
         "phpunit/phpunit": "^5.5"
     },
     "autoload": {

--- a/src/MailThiefPendingMail.php
+++ b/src/MailThiefPendingMail.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MailThief;
+
+use Illuminate\Mail\PendingMail;
+
+class MailThiefPendingMail extends PendingMail
+{
+    public function __construct(MailThief $mailer)
+    {
+        $this->mailer = $mailer;
+    }
+}

--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -56,7 +56,9 @@ trait InteractsWithMail
     /** @before */
     public function hijackMail()
     {
-        $this->getMailer()->hijack();
+        $this->afterApplicationCreated(function() {
+            $this->getMailer()->hijack();
+        });
     }
 
     public function seeMessageFor($email)


### PR DESCRIPTION
This pull request is meant to resolve the breaking changes of laravel 5.5 so we can all continue to enjoy using mailthief. You can refer to issue #76 to see why this was necessary. In short, the `queue()` and `later()` type functions of the `Mailer` class now only support handling `Mailable` class objects, and their respective function signatures have changed.

This pull request should take care of supporting Mailables in general for 5.5. Both the `send()` and `later()` functions of `MailThief` run the `Mailable` class objects through the render pipeline before assigning to `$this->messages[]` and `$this->later[]` respectively (note: `$mailable->send($this)` calls `$mailer->send()` from the `Mailable` class). 

I also had to get somewhat clever on the `later()` function with reflection. The `Mailable` class object has protected methods that still need to be accessed by `MailThief` in order to prepare a `Message` for `later[]`.