### PR TITLE
[Bugfix] Update InteractsWithMail to account for older versions of phpunit

### DIFF
--- a/src/Testing/InteractsWithMail.php
+++ b/src/Testing/InteractsWithMail.php
@@ -56,7 +56,7 @@ trait InteractsWithMail
     /** @before */
     public function hijackMail()
     {
-        if ((float) $this->app->version() >= 5.5) {
+        if (method_exists($this, 'afterApplicationCreated')) {
             $this->afterApplicationCreated(function () {
                 $this->getMailer()->hijack();
             });


### PR DESCRIPTION
This is a quick fix to account for older versions of phpunit (< v6) not being able to access $this->app before `setup()` is called by phpunit. Instead, the `hijackMail()` function now uses `method_exists()` for the `afterApplicationCreated()` function.