### PR TITLE
Mailthief breaks in 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "illuminate/mail": "5.*",
+        "illuminate/mail": "<5.4",
         "illuminate/view": "5.*"
     },
     "require-dev": {


### PR DESCRIPTION
The `Mail::send()` expects a string in <5.4 but in 5.4 and above, there are Mail fakes, and the `Mail::send()` method expects a `Mailable` class