### PR TITLE
Test to prove #81 was actually fixed!

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     },
     "autoload-dev": {
         "classmap": [
-            "tests/TestCase.php"
+            "tests/TestCase.php",
+            "tests/AppStub.php"
         ]
     }
 }

--- a/tests/AppStub.php
+++ b/tests/AppStub.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Foundation\Application;
+
+class AppStub extends Application implements ArrayAccess
+{
+    private $foo;
+    private $mailer;
+    protected $attributes = [];
+
+    public function setAttributes($attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function version()
+    {
+        return 5.4;
+    }
+
+    public function instance($key, $instance)
+    {
+        $this->attributes[$key] = $instance;
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->attributes[$offset]);
+    }
+
+    public function offsetGet($key)
+    {
+        return $this->attributes[$key];
+    }
+
+    public function offsetSet($key, $value)
+    {
+        $this->attributes[$key] = $value;
+    }
+
+    public function offsetUnset($key)
+    {
+        unset($this->attributes[$key]);
+    }
+}

--- a/tests/AppStub.php
+++ b/tests/AppStub.php
@@ -4,8 +4,6 @@ use Illuminate\Foundation\Application;
 
 class AppStub extends Application implements ArrayAccess
 {
-    private $foo;
-    private $mailer;
     protected $attributes = [];
 
     public function setAttributes($attributes)

--- a/tests/MailFacadeIntegrationTest.php
+++ b/tests/MailFacadeIntegrationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Mail;
+use MailThief\Facades\MailThief;
+use MailThief\Testing\InteractsWithMail;
+use MailThief\MailThiefFiveFourCompatible;
+
+class MailFacadeIntegrationTest extends TestCase
+{
+    use InteractsWithMail;
+
+    public function setUp()
+    {
+        $app = new AppStub;
+        $app->setAttributes([
+            MailThiefFiveFourCompatible::class => $this->getMailThief(),
+        ]);
+
+        Facade::setFacadeApplication($app);
+
+        parent::setUp();
+    }
+
+    public function test_previously_set_instance_of_mailthief_doesnt_change()
+    {
+        Mail::send('example-view', [], function ($m) {
+            $m->to('john@example.com');
+        });
+
+        $this->seeMessageFor('john@example.com');
+
+        MailThief::swap($this->getMailThief());
+
+        Mail::send('example-view', [], function ($m) {
+            $m->to('jay@example.com');
+        });
+
+        $this->seeMessageFor('jay@example.com');
+    }
+}


### PR DESCRIPTION
Okay so bear with me on this one! I only added the minimum required necessities to get this test to pass. If you check out this branch and change `getMailer` to `return $this->mailer ?: MailThief::getFacadeRoot()` then you'll see this break.

Let me know if I didn't follow naming conventions, style guide, etc!