### PR TITLE
Allow mailer to intercept Mailable objects

### DIFF
--- a/src/MailThief.php
+++ b/src/MailThief.php
@@ -2,14 +2,13 @@
 
 namespace MailThief;
 
-use Illuminate\Contracts\Mail\MailQueue;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\HtmlString;
-use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use InvalidArgumentException;
 use MailThief\Support\MailThiefCollection;
 
@@ -60,6 +59,12 @@ abstract class MailThief
 
     public function send($view, array $data = [], $callback = null)
     {
+        if ($view instanceof Mailable) {
+            $view->send($this);
+
+            return;
+        }
+
         $callback = $callback ?: null;
 
         $data['message'] = new NullMessageForView;

--- a/tests/InteractsWithMailTest.php
+++ b/tests/InteractsWithMailTest.php
@@ -190,4 +190,20 @@ class InteractsWithMailTest extends TestCase
         $this->seeMessageFrom('me@example.com');
         $this->seeMessageFrom('me@example.com', 'Example Person');
     }
+
+    public function test_with_mailables()
+    {
+        $mailer = $this->mailer = $this->getMailThief();
+
+        $mailable = new TestMailable();
+        $mailable->to('john@example.com')
+            ->from('me@example.com', 'Example Person')
+            ->subject('Message for you');
+
+        $mailer->send($mailable);
+
+        $this->seeMessageFrom('me@example.com');
+        $this->seeMessageFrom('me@example.com', 'Example Person');
+        $this->seeInSubjects('Message for you');
+    }
 }

--- a/tests/MailThiefTest.php
+++ b/tests/MailThiefTest.php
@@ -450,4 +450,13 @@ class MailThiefTest extends TestCase
 
         $this->assertEquals($messages, $mailer->subjects()->all());
     }
+
+    public function test_it_sends_mailables()
+    {
+        $mailer = $this->mailer = $this->getMailThief();
+        $mailable = new TestMailable();
+        $mailable->to('john@example.com');
+        $mailer->send($mailable);
+        $this->assertTrue($mailer->hasMessageFor('john@example.com'));
+    }
 }

--- a/tests/MailThiefTest.php
+++ b/tests/MailThiefTest.php
@@ -453,7 +453,7 @@ class MailThiefTest extends TestCase
 
     public function test_it_sends_mailables()
     {
-        $mailer = $this->mailer = $this->getMailThief();
+        $mailer = $this->getMailThief();
         $mailable = new TestMailable();
         $mailable->to('john@example.com');
         $mailer->send($mailable);

--- a/tests/TestMailable.php
+++ b/tests/TestMailable.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Mail\Mailable;
+
+class TestMailable extends Mailable
+{
+    public function build()
+    {
+        return $this->view('example-view');
+    }
+}


### PR DESCRIPTION
in reference to #90
This lets mailthief intercept "Mailables"

note: My IDE sorted the imports and discarded the unused ones.