### PR TITLE
Fix version issue with Lumen.

### DIFF
--- a/src/Facades/MailThief.php
+++ b/src/Facades/MailThief.php
@@ -10,7 +10,18 @@ class MailThief extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return (float) self::$app->version() >= 5.5
+    	$appVersion = self::$app->version();
+
+		$versions = [];
+
+		// Take the first version from whatever string we are passed.
+		preg_match("/[0-9]\.[0-9]/", $appVersion, $versions);
+		$appVersion = $versions[0];
+    	
+    	$appVersion = (float) $appVersion;
+
+
+        return $appVersion >= 5.5
             ? MailThiefFiveFiveCompatible::class
             : MailThiefFiveFourCompatible::class;
     }


### PR DESCRIPTION
This is to address interoperability with MailThief and Lumen per issue #92. The check simply takes the first match and uses that to compare. This shouldn't cause any issues with Laravel or Lumen, and I've tested it with the version returned from Lumen and from Laravel. Both work with no issues.