### PR TITLE
Update readme with note that app will remain at laravel 5.5.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,9 @@
 
 MailThief is a fake mailer for Laravel applications (5.0+) that makes it easy to test mail without actually sending any emails.
 
+#### Note: 
+Due to changes in the way mail testing is handled by Laravel; MailThief is not needed for recent versions of the framework. As such, MailThief will remain at Laravel 5.5.
+
 ## Quickstart
 
 Installation:

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 MailThief is a fake mailer for Laravel applications (5.0+) that makes it easy to test mail without actually sending any emails.
 
 #### Note: 
-Due to changes in the way mail testing is handled by Laravel; MailThief is not needed for recent versions of the framework. As such, MailThief will remain at Laravel 5.5.
+Due to changes in the way mail testing is handled by Laravel; MailThief is not needed for recent versions of the framework. MailThief will remain compatible with Laravel up to version 5.5.
 
 ## Quickstart
 


### PR DESCRIPTION
This PR adds a note to the Readme informing users that MailThief will no longer be updated beyond Laravel 5.5.